### PR TITLE
Remove piwheels.org repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-bullseye AS builder
 # install/compile wheels
 WORKDIR /usr/src/app
 COPY requirements.txt ./
-RUN pip wheel --no-cache-dir --prefer-binary --extra-index-url https://www.piwheels.org/simple --wheel-dir /usr/wheels -r requirements.txt
+RUN pip wheel --no-cache-dir --prefer-binary --wheel-dir /usr/wheels -r requirements.txt
 
 
 FROM python:3.11-slim-bullseye

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ pip install -r requirements-dev.txt -U
 pip-compile --upgrade --resolver backtracking --allow-unsafe requirements.in
 
 # edit requirements.txt and add/edit platform specific dependencies: RPi.GPIO
-# check that all requirements are available for arm7 on https://www.piwheels.org/packages.html, especially cryptography
 pip install -r requirements.txt -U
 ```
 


### PR DESCRIPTION
- looks like all wheels are available on PyPI or can be built w/o extra tools