### PR TITLE
feat: add optional MQTT publishing with HA discovery

### DIFF
--- a/pvcontrol/__main__.py
+++ b/pvcontrol/__main__.py
@@ -21,6 +21,7 @@ parser.add_argument("-w", "--wallbox", default="SimulatedWallbox")
 parser.add_argument("-r", "--relay", default="SimulatedPhaseRelay")
 parser.add_argument("-a", "--car", default="SimulatedCar")
 parser.add_argument("-c", "--config", default="{}")
+parser.add_argument("--mqtt", action="store_true", default=False, help="enable MQTT publishing")
 parser.add_argument("--hostname", default="", help="server hostname, can be used to enable/disable phase relay on k8s")
 parser.add_argument("--host", default="0.0.0.0", help="server host (default: 0.0.0.0)")
 parser.add_argument("--port", type=int, default=8080, help="server port (default: 8080)")
@@ -35,7 +36,7 @@ logger.info(f"config:  {args.config}")
 logger.info(f"hostname:{args.hostname}")
 logger.info(f"Running on {platform.machine()} / {sys.platform}")
 config = json.loads(args.config)
-for c in ["wallbox", "meter", "car", "controller", "relay"]:
+for c in ["wallbox", "meter", "car", "controller", "relay", "mqtt"]:
     if c not in config:
         config[c] = {}
 

--- a/pvcontrol/app.py
+++ b/pvcontrol/app.py
@@ -57,6 +57,7 @@ args = Namespace(
     relay="SimulatedPhaseRelay",
     car="SimulatedCar",
     hostname="",
+    mqtt=False,
 )
 config: dict[str, Any] = {"wallbox": {}, "meter": {}, "car": {}, "controller": {}, "relay": {}}
 

--- a/pvcontrol/dependencies.py
+++ b/pvcontrol/dependencies.py
@@ -5,6 +5,7 @@ from typing import Any
 from pvcontrol.car import Car, CarFactory
 from pvcontrol.chargecontroller import ChargeController, ChargeControllerFactory
 from pvcontrol.meter import Meter, MeterFactory
+from pvcontrol.mqtt import MqttConfig, MqttPublisher
 from pvcontrol.relay import PhaseRelay, PhaseRelayFactory
 from pvcontrol.scheduler import AsyncScheduler
 from pvcontrol.wallbox import Wallbox, WallboxFactory
@@ -27,11 +28,13 @@ controller: ChargeController = None  # ty:ignore[invalid-assignment]
 car: Car[Any] = None  # ty:ignore[invalid-assignment]
 controller_scheduler: AsyncScheduler = None  # ty:ignore[invalid-assignment]
 car_scheduler: AsyncScheduler = None  # ty:ignore[invalid-assignment]
+mqtt_publisher: MqttPublisher | None = None
+mqtt_scheduler: AsyncScheduler | None = None
 
 
 async def init(args: Namespace, config: dict[str, Any]) -> None:
     logger.info("Initializing depencencies.")
-    global controller_scheduler, car_scheduler, relay, wallbox, meter, car, controller
+    global controller_scheduler, car_scheduler, relay, wallbox, meter, car, controller, mqtt_publisher, mqtt_scheduler
     relay = PhaseRelayFactory.newPhaseRelay(args.relay, args.hostname, **config["relay"])
     wallbox = WallboxFactory.newWallbox(args.wallbox, relay, **config["wallbox"])
     meter = MeterFactory.newMeter(args.meter, wallbox, **config["meter"])
@@ -43,9 +46,20 @@ async def init(args: Namespace, config: dict[str, Any]) -> None:
     await controller_scheduler.start()
     await car_scheduler.start()
 
+    if args.mqtt:
+        mqtt_config = MqttConfig(**config["mqtt"])
+        mqtt_publisher = MqttPublisher(mqtt_config, version)
+        await mqtt_publisher.start()
+        mqtt_scheduler = AsyncScheduler(controller.get_config().cycle_time, mqtt_publisher.publish_state)
+        await mqtt_scheduler.start()
+
 
 # shutdown components and event loop
 async def shutdown():
+    if mqtt_scheduler:
+        await mqtt_scheduler.stop()
+    if mqtt_publisher:
+        await mqtt_publisher.stop()
     await controller_scheduler.stop()
     await car_scheduler.stop()
     # disable charging to play it safe

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -1,0 +1,407 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiomqtt
+
+from pvcontrol.chargecontroller import ChargeMode, PhaseMode, Priority
+from pvcontrol.wallbox import CarStatus, WbError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MqttConfig:
+    broker: str = "localhost"
+    port: int = 1883
+    username: str = ""
+    password: str = ""
+    topic_prefix: str = "pvcontrol"
+    ha_discovery_prefix: str = "homeassistant"
+
+
+@dataclass
+class EntityDef:
+    component: str
+    object_id: str
+    name: str
+    value_template: str
+    device_class: str | None = None
+    state_class: str | None = None
+    unit_of_measurement: str | None = None
+    entity_category: str | None = None
+    options: list[str] = field(default_factory=list)
+
+
+ENTITY_DEFINITIONS: list[EntityDef] = [
+    # Meter
+    EntityDef(
+        "sensor",
+        "meter_power_pv",
+        "PV Power",
+        "{{ value_json.meter.power_pv | round(0) }}",
+        device_class="power",
+        state_class="measurement",
+        unit_of_measurement="W",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_power_consumption",
+        "Consumption Power",
+        "{{ value_json.meter.power_consumption | round(0) }}",
+        device_class="power",
+        state_class="measurement",
+        unit_of_measurement="W",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_power_grid",
+        "Grid Power",
+        "{{ value_json.meter.power_grid | round(0) }}",
+        device_class="power",
+        state_class="measurement",
+        unit_of_measurement="W",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_power_battery",
+        "Battery Power",
+        "{{ value_json.meter.power_battery | round(0) }}",
+        device_class="power",
+        state_class="measurement",
+        unit_of_measurement="W",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_soc_battery",
+        "Battery SoC",
+        "{{ value_json.meter.soc_battery | round(0) }}",
+        device_class="battery",
+        state_class="measurement",
+        unit_of_measurement="%",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_energy_consumption",
+        "Energy Consumption",
+        "{{ value_json.meter.energy_consumption | round(0) }}",
+        device_class="energy",
+        state_class="total_increasing",
+        unit_of_measurement="Wh",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_energy_consumption_grid",
+        "Energy Consumption Grid",
+        "{{ value_json.meter.energy_consumption_grid | round(0) }}",
+        device_class="energy",
+        state_class="total_increasing",
+        unit_of_measurement="Wh",
+    ),
+    EntityDef(
+        "sensor",
+        "meter_energy_consumption_pv",
+        "Energy Consumption PV",
+        "{{ value_json.meter.energy_consumption_pv | round(0) }}",
+        device_class="energy",
+        state_class="total_increasing",
+        unit_of_measurement="Wh",
+    ),
+    # Wallbox
+    EntityDef(
+        "sensor",
+        "wallbox_car_status",
+        "Car Status",
+        "{{ value_json.wallbox.car_status }}",
+        device_class="enum",
+        options=[s.name for s in CarStatus],
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_max_current",
+        "Max Current",
+        "{{ value_json.wallbox.max_current }}",
+        device_class="current",
+        state_class="measurement",
+        unit_of_measurement="A",
+    ),
+    EntityDef("binary_sensor", "wallbox_allow_charging", "Allow Charging", "{{ 'ON' if value_json.wallbox.allow_charging else 'OFF' }}"),
+    EntityDef("sensor", "wallbox_phases_in", "Phases In", "{{ value_json.wallbox.phases_in }}", state_class="measurement"),
+    EntityDef("sensor", "wallbox_phases_out", "Phases Out", "{{ value_json.wallbox.phases_out }}", state_class="measurement"),
+    EntityDef(
+        "sensor",
+        "wallbox_power",
+        "Wallbox Power",
+        "{{ value_json.wallbox.power | round(0) }}",
+        device_class="power",
+        state_class="measurement",
+        unit_of_measurement="W",
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_charged_energy",
+        "Charged Energy",
+        "{{ value_json.wallbox.charged_energy | round(0) }}",
+        device_class="energy",
+        state_class="total_increasing",
+        unit_of_measurement="Wh",
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_total_energy",
+        "Total Energy",
+        "{{ value_json.wallbox.total_energy | round(0) }}",
+        device_class="energy",
+        state_class="total_increasing",
+        unit_of_measurement="Wh",
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_temperature",
+        "Wallbox Temperature",
+        "{{ value_json.wallbox.temperature }}",
+        device_class="temperature",
+        state_class="measurement",
+        unit_of_measurement="°C",
+    ),
+    # Relay
+    EntityDef("binary_sensor", "relay_enabled", "Phase Relay Enabled", "{{ 'ON' if value_json.relay.enabled else 'OFF' }}"),
+    EntityDef("sensor", "relay_phases", "Relay Phases", "{{ value_json.relay.phases }}", state_class="measurement"),
+    # Controller
+    EntityDef(
+        "sensor",
+        "controller_mode",
+        "Charge Mode",
+        "{{ value_json.controller.mode }}",
+        device_class="enum",
+        options=[m.value for m in ChargeMode],
+    ),
+    EntityDef(
+        "sensor",
+        "controller_desired_mode",
+        "Desired Charge Mode",
+        "{{ value_json.controller.desired_mode }}",
+        device_class="enum",
+        options=[m.value for m in ChargeMode],
+    ),
+    EntityDef(
+        "sensor",
+        "controller_phase_mode",
+        "Phase Mode",
+        "{{ value_json.controller.phase_mode }}",
+        device_class="enum",
+        options=[m.value for m in PhaseMode],
+    ),
+    EntityDef(
+        "sensor",
+        "controller_priority",
+        "Priority",
+        "{{ value_json.controller.priority }}",
+        device_class="enum",
+        options=[m.value for m in Priority],
+    ),
+    EntityDef(
+        "sensor",
+        "controller_desired_priority",
+        "Desired Priority",
+        "{{ value_json.controller.desired_priority }}",
+        device_class="enum",
+        options=[m.value for m in Priority],
+    ),
+    # Car
+    EntityDef(
+        "sensor",
+        "car_soc",
+        "Car SoC",
+        "{{ value_json.car.soc | round(0) }}",
+        device_class="battery",
+        state_class="measurement",
+        unit_of_measurement="%",
+    ),
+    EntityDef(
+        "sensor",
+        "car_cruising_range",
+        "Car Cruising Range",
+        "{{ value_json.car.cruising_range }}",
+        device_class="distance",
+        state_class="measurement",
+        unit_of_measurement="km",
+    ),
+    EntityDef(
+        "sensor",
+        "car_mileage",
+        "Car Mileage",
+        "{{ value_json.car.mileage }}",
+        device_class="distance",
+        state_class="total_increasing",
+        unit_of_measurement="km",
+    ),
+    # Diagnostics
+    EntityDef(
+        "sensor", "meter_error", "Meter Errors", "{{ value_json.meter.error }}", state_class="measurement", entity_category="diagnostic"
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_wb_error",
+        "Wallbox Error",
+        "{{ value_json.wallbox.wb_error }}",
+        device_class="enum",
+        entity_category="diagnostic",
+        options=[e.name for e in WbError],
+    ),
+    EntityDef(
+        "sensor",
+        "wallbox_error",
+        "Wallbox Error Count",
+        "{{ value_json.wallbox.error }}",
+        state_class="measurement",
+        entity_category="diagnostic",
+    ),
+    EntityDef(
+        "sensor", "relay_error", "Relay Errors", "{{ value_json.relay.error }}", state_class="measurement", entity_category="diagnostic"
+    ),
+    EntityDef(
+        "sensor",
+        "controller_error",
+        "Controller Errors",
+        "{{ value_json.controller.error }}",
+        state_class="measurement",
+        entity_category="diagnostic",
+    ),
+    EntityDef("sensor", "car_error", "Car Errors", "{{ value_json.car.error }}", state_class="measurement", entity_category="diagnostic"),
+    EntityDef(
+        "sensor",
+        "car_data_captured_at",
+        "Car Data Captured At",
+        "{{ value_json.car.data_captured_at }}",
+        device_class="timestamp",
+        entity_category="diagnostic",
+    ),
+]
+
+
+class MqttPublisher:
+    def __init__(self, config: MqttConfig, version: str):
+        self._config = config
+        self._version = version
+        self._client: aiomqtt.Client | None = None
+        self._next_reconnect_at: float = 0
+
+    async def start(self) -> None:
+        try:
+            self._client = aiomqtt.Client(
+                hostname=self._config.broker,
+                port=self._config.port,
+                username=self._config.username or None,
+                password=self._config.password or None,
+                identifier="pvcontrol",
+                will=aiomqtt.Will(
+                    topic=f"{self._config.topic_prefix}/status",
+                    payload="offline",
+                    retain=True,
+                ),
+            )
+            await self._client.__aenter__()
+            await self._client.publish(f"{self._config.topic_prefix}/status", payload="online", retain=True)
+            await self._publish_discovery()
+            self._next_reconnect_at = 0
+            logger.info(f"MQTT connected to {self._config.broker}:{self._config.port}")
+        except Exception:
+            logger.exception("MQTT connection failed")
+            await self._disconnect()
+
+    async def stop(self) -> None:
+        if self._client:
+            try:
+                await self._client.publish(f"{self._config.topic_prefix}/status", payload="offline", retain=True)
+            except Exception:
+                pass
+            await self._disconnect()
+
+    async def publish_state(self) -> None:
+        if self._client is None:
+            await self._try_reconnect()
+        if self._client is None:
+            return
+        try:
+            from pvcontrol import dependencies
+
+            state = self._build_state(dependencies)
+            payload = json.dumps(state)
+            await self._client.publish(f"{self._config.topic_prefix}/state", payload=payload, retain=True)
+        except aiomqtt.MqttError as e:
+            logger.warning(f"MQTT publish failed: {e}")
+            await self._disconnect()
+        except Exception:
+            logger.exception("MQTT publish error")
+
+    def _build_state(self, deps: Any) -> dict[str, Any]:
+        from pvcontrol.api import PvcontrolResponse
+
+        response = PvcontrolResponse(
+            version=deps.version,
+            controller=deps.controller.get_data(),
+            meter=deps.meter.get_data(),
+            wallbox=deps.wallbox.get_data(),
+            relay=deps.relay.get_data(),
+            car=deps.car.get_data(),
+        )
+        state = response.model_dump(mode="json")
+        state["wallbox"]["car_status"] = CarStatus(state["wallbox"]["car_status"]).name
+        state["wallbox"]["wb_error"] = WbError(state["wallbox"]["wb_error"]).name
+        return state
+
+    async def _disconnect(self) -> None:
+        if self._client:
+            try:
+                await self._client.__aexit__(None, None, None)
+            except Exception:
+                pass
+            self._client = None
+
+    async def _publish_discovery(self) -> None:
+        if self._client is None:
+            return
+        device_info = {
+            "identifiers": ["pvcontrol"],
+            "name": "PV Control",
+            "manufacturer": "pv-control",
+            "sw_version": self._version,
+        }
+        availability = {
+            "topic": f"{self._config.topic_prefix}/status",
+            "payload_available": "online",
+            "payload_not_available": "offline",
+        }
+        for entity in ENTITY_DEFINITIONS:
+            topic = f"{self._config.ha_discovery_prefix}/{entity.component}/pvcontrol_{entity.object_id}/config"
+            payload: dict[str, Any] = {
+                "name": entity.name,
+                "unique_id": f"pvcontrol_{entity.object_id}",
+                "object_id": f"pvcontrol_{entity.object_id}",
+                "state_topic": f"{self._config.topic_prefix}/state",
+                "value_template": entity.value_template,
+                "device": device_info,
+                "availability": availability,
+            }
+            if entity.device_class:
+                payload["device_class"] = entity.device_class
+            if entity.state_class:
+                payload["state_class"] = entity.state_class
+            if entity.unit_of_measurement:
+                payload["unit_of_measurement"] = entity.unit_of_measurement
+            if entity.entity_category:
+                payload["entity_category"] = entity.entity_category
+            if entity.options:
+                payload["options"] = entity.options
+            await self._client.publish(topic, payload=json.dumps(payload), retain=True)
+
+    async def _try_reconnect(self) -> None:
+        import time
+
+        now = time.monotonic()
+        if now < self._next_reconnect_at:
+            return
+        self._next_reconnect_at = now + 60
+        await self.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "aiodns==4.0.0",
     "aiohttp==3.13.5",
+    "aiomqtt==2.5.1",
     "fastapi==0.136.1",
     "myskoda==2.11.0",
     "prometheus-client==0.25.0",

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,0 +1,207 @@
+import json
+import unittest
+from typing import Any, final, override
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pvcontrol.chargecontroller import ChargeMode, PhaseMode, Priority
+from pvcontrol.mqtt import ENTITY_DEFINITIONS, MqttConfig, MqttPublisher
+from pvcontrol.wallbox import CarStatus, WbError
+
+
+@final
+class MqttConfigTest(unittest.TestCase):
+    def test_defaults(self):
+        config = MqttConfig()
+        self.assertEqual("localhost", config.broker)
+        self.assertEqual(1883, config.port)
+        self.assertEqual("", config.username)
+        self.assertEqual("", config.password)
+        self.assertEqual("pvcontrol", config.topic_prefix)
+        self.assertEqual("homeassistant", config.ha_discovery_prefix)
+
+    def test_from_kwargs(self):
+        config = MqttConfig(broker="192.168.1.100", port=8883, username="user", password="pass")
+        self.assertEqual("192.168.1.100", config.broker)
+        self.assertEqual(8883, config.port)
+        self.assertEqual("user", config.username)
+        self.assertEqual("pass", config.password)
+
+
+@final
+class EntityDefinitionsTest(unittest.TestCase):
+    def test_all_entities_have_required_fields(self):
+        for entity in ENTITY_DEFINITIONS:
+            self.assertIn(entity.component, ("sensor", "binary_sensor"))
+            self.assertTrue(entity.object_id)
+            self.assertTrue(entity.name)
+            self.assertTrue(entity.value_template)
+
+    def test_unique_object_ids(self):
+        ids = [e.object_id for e in ENTITY_DEFINITIONS]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_enum_sensors_have_options(self):
+        enum_entities = [e for e in ENTITY_DEFINITIONS if e.device_class == "enum"]
+        for entity in enum_entities:
+            self.assertTrue(entity.options, f"{entity.object_id} has device_class=enum but no options")
+
+    def test_charge_mode_options(self):
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "controller_mode")
+        self.assertEqual(entity.options, [m.value for m in ChargeMode])
+
+    def test_car_status_options(self):
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "wallbox_car_status")
+        self.assertEqual(entity.options, [s.name for s in CarStatus])
+
+    def test_wb_error_options(self):
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "wallbox_wb_error")
+        self.assertEqual(entity.options, [e.name for e in WbError])
+
+
+@final
+class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
+    @override
+    def setUp(self):
+        self.config = MqttConfig(broker="testhost", port=1883)
+        self.publisher = MqttPublisher(self.config, "1.0.0")
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_start_connects_and_publishes_discovery(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+
+        mock_client_cls.assert_called_once()
+        call_kwargs = mock_client_cls.call_args.kwargs
+        self.assertEqual("testhost", call_kwargs["hostname"])
+        self.assertEqual(1883, call_kwargs["port"])
+
+        # Should publish online status + all discovery messages
+        expected_publish_count = 1 + len(ENTITY_DEFINITIONS)
+        self.assertEqual(expected_publish_count, mock_client.publish.call_count)
+
+        # First call should be the online status
+        first_call = mock_client.publish.call_args_list[0]
+        self.assertEqual("pvcontrol/status", first_call.args[0] if first_call.args else first_call.kwargs.get("topic"))
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_discovery_payload_structure(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+
+        # Check a discovery publish (skip first which is online status)
+        discovery_call = mock_client.publish.call_args_list[1]
+        topic: str = discovery_call.args[0] if discovery_call.args else discovery_call.kwargs["topic"]
+        payload_str = discovery_call.kwargs.get("payload") or discovery_call.args[1]
+        payload = json.loads(payload_str)
+
+        self.assertIn("homeassistant/", topic)
+        self.assertIn("name", payload)
+        self.assertIn("unique_id", payload)
+        self.assertIn("state_topic", payload)
+        self.assertIn("value_template", payload)
+        self.assertIn("device", payload)
+        self.assertIn("availability", payload)
+        self.assertEqual("pvcontrol/state", payload["state_topic"])
+        self.assertEqual("1.0.0", payload["device"]["sw_version"])
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_start_failure_does_not_crash(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(side_effect=OSError("Connection refused"))
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+        self.assertIsNone(self.publisher._client)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_stop_publishes_offline(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+        mock_client.publish.reset_mock()
+        await self.publisher.stop()
+
+        mock_client.publish.assert_called_once()
+        call_kwargs = mock_client.publish.call_args.kwargs
+        self.assertEqual("pvcontrol/status", mock_client.publish.call_args.args[0])
+        self.assertEqual("offline", call_kwargs["payload"])
+
+    async def test_publish_state_without_connection_does_not_crash(self):
+        self.publisher._client = None
+        # Should not raise even without connection (reconnect also fails silently)
+        with patch.object(self.publisher, "_try_reconnect", new_callable=AsyncMock):
+            await self.publisher.publish_state()
+
+    def test_build_state_converts_int_enums(self):
+        deps = MagicMock()
+        deps.version = "1.0.0"
+
+        controller_data = MagicMock()
+        controller_data.mode = ChargeMode.PV_ONLY
+        controller_data.desired_mode = ChargeMode.PV_ONLY
+        controller_data.phase_mode = PhaseMode.AUTO
+        controller_data.priority = Priority.AUTO
+        controller_data.desired_priority = Priority.AUTO
+        controller_data.error = 0
+        deps.controller.get_data.return_value = controller_data
+
+        meter_data = MagicMock()
+        meter_data.power_pv = 3000.0
+        deps.meter.get_data.return_value = meter_data
+
+        wallbox_data = MagicMock()
+        wallbox_data.car_status = CarStatus.Charging
+        wallbox_data.wb_error = WbError.OK
+        deps.wallbox.get_data.return_value = wallbox_data
+
+        relay_data = MagicMock()
+        deps.relay.get_data.return_value = relay_data
+
+        car_data = MagicMock()
+        deps.car.get_data.return_value = car_data
+
+        with patch("pvcontrol.api.PvcontrolResponse") as mock_response_cls:
+            mock_response = MagicMock()
+            mock_response.model_dump.return_value = {
+                "version": "1.0.0",
+                "controller": {"mode": "PV_ONLY", "error": 0},
+                "meter": {"power_pv": 3000.0},
+                "wallbox": {"car_status": 2, "wb_error": 0},
+                "relay": {},
+                "car": {},
+            }
+            mock_response_cls.return_value = mock_response
+
+            state = self.publisher._build_state(deps)
+
+        self.assertEqual("Charging", state["wallbox"]["car_status"])
+        self.assertEqual("OK", state["wallbox"]["wb_error"])
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_lwt_configured(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+
+        call_kwargs = mock_client_cls.call_args.kwargs
+        will = call_kwargs["will"]
+        self.assertEqual("pvcontrol/status", str(will.topic))
+        self.assertEqual("offline", will.payload)

--- a/uv.lock
+++ b/uv.lock
@@ -617,6 +617,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiodns" },
     { name = "aiohttp" },
+    { name = "aiomqtt" },
     { name = "fastapi" },
     { name = "myskoda" },
     { name = "prometheus-client" },
@@ -637,6 +638,7 @@ dev = [
 requires-dist = [
     { name = "aiodns", specifier = "==4.0.0" },
     { name = "aiohttp", specifier = "==3.13.5" },
+    { name = "aiomqtt", specifier = "==2.5.1" },
     { name = "fastapi", specifier = "==0.136.1" },
     { name = "myskoda", specifier = "==2.11.0" },
     { name = "prometheus-client", specifier = "==0.25.0" },


### PR DESCRIPTION
Publish system state (meter, wallbox, relay, controller, car) to an MQTT broker every 30s with retained messages. Home Assistant auto- discovers all sensors via per-entity discovery topics. Enabled with --mqtt flag; broker/credentials configured via --config JSON.

Uses aiomqtt for async MQTT, includes LWT for availability tracking and reconnect with 60s backoff.