### PR TITLE
feat(mqtt): restore pvcontrol from retained mqtt state on startup

### DIFF
--- a/pvcontrol/dependencies.py
+++ b/pvcontrol/dependencies.py
@@ -50,6 +50,7 @@ async def init(args: Namespace, config: dict[str, Any]) -> None:
         mqtt_config = MqttConfig(**config["mqtt"])
         mqtt_publisher = MqttPublisher(mqtt_config, version)
         await mqtt_publisher.start()
+        await mqtt_publisher.restore_state()
         mqtt_scheduler = AsyncScheduler(controller.get_config().cycle_time, mqtt_publisher.publish_state)
         await mqtt_scheduler.start()
 

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -405,3 +406,46 @@ class MqttPublisher:
             return
         self._next_reconnect_at = now + 60
         await self.start()
+
+    async def restore_state(self) -> None:
+        if self._client is None:
+            return
+        topic = f"{self._config.topic_prefix}/state"
+        try:
+            await self._client.subscribe(topic)
+            msg = await asyncio.wait_for(anext(self._client.messages), timeout=2.0)
+            payload = json.loads(msg.payload)
+            self._apply_controller_state(payload)
+        except TimeoutError:
+            logger.info("No retained MQTT state found, starting with defaults")
+        except Exception:
+            logger.exception("Failed to restore state from MQTT")
+        finally:
+            try:
+                if self._client is not None:
+                    await self._client.unsubscribe(topic)
+            except Exception:
+                pass
+
+    def _apply_controller_state(self, payload: dict[str, Any]) -> None:
+        from pvcontrol import dependencies
+
+        controller_state = payload.get("controller", {})
+        if desired_mode := controller_state.get("desired_mode"):
+            try:
+                dependencies.controller.set_desired_mode(ChargeMode(desired_mode))
+                logger.info(f"Restored desired_mode: {desired_mode}")
+            except ValueError:
+                logger.warning(f"Ignoring invalid desired_mode from retained state: {desired_mode!r}")
+        if phase_mode := controller_state.get("phase_mode"):
+            try:
+                dependencies.controller.set_phase_mode(PhaseMode(phase_mode))
+                logger.info(f"Restored phase_mode: {phase_mode}")
+            except ValueError:
+                logger.warning(f"Ignoring invalid phase_mode from retained state: {phase_mode!r}")
+        if desired_priority := controller_state.get("desired_priority"):
+            try:
+                dependencies.controller.set_desired_priority(Priority(desired_priority))
+                logger.info(f"Restored desired_priority: {desired_priority}")
+            except ValueError:
+                logger.warning(f"Ignoring invalid desired_priority from retained state: {desired_priority!r}")

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -326,9 +326,13 @@ class MqttPublisher:
         if self._client is None:
             return
         try:
-            from pvcontrol import dependencies
+            import pvcontrol.api as api
 
-            state = self._build_state(dependencies)
+            response = await api.get_root()
+            state = response.model_dump(mode="json")
+            state["wallbox"]["car_status"] = CarStatus(state["wallbox"]["car_status"]).name
+            state["wallbox"]["wb_error"] = WbError(state["wallbox"]["wb_error"]).name
+
             payload = json.dumps(state)
             await self._client.publish(f"{self._config.topic_prefix}/state", payload=payload, retain=True)
         except aiomqtt.MqttError as e:
@@ -336,22 +340,6 @@ class MqttPublisher:
             await self._disconnect()
         except Exception:
             logger.exception("MQTT publish error")
-
-    def _build_state(self, deps: Any) -> dict[str, Any]:
-        from pvcontrol.api import PvcontrolResponse
-
-        response = PvcontrolResponse(
-            version=deps.version,
-            controller=deps.controller.get_data(),
-            meter=deps.meter.get_data(),
-            wallbox=deps.wallbox.get_data(),
-            relay=deps.relay.get_data(),
-            car=deps.car.get_data(),
-        )
-        state = response.model_dump(mode="json")
-        state["wallbox"]["car_status"] = CarStatus(state["wallbox"]["car_status"]).name
-        state["wallbox"]["wb_error"] = WbError(state["wallbox"]["wb_error"]).name
-        return state
 
     async def _disconnect(self) -> None:
         if self._client:
@@ -415,7 +403,7 @@ class MqttPublisher:
             await self._client.subscribe(topic)
             msg = await asyncio.wait_for(anext(self._client.messages), timeout=2.0)
             payload = json.loads(msg.payload)
-            self._apply_controller_state(payload)
+            await self._apply_controller_state(payload)
         except TimeoutError:
             logger.info("No retained MQTT state found, starting with defaults")
         except Exception:
@@ -427,25 +415,25 @@ class MqttPublisher:
             except Exception:
                 pass
 
-    def _apply_controller_state(self, payload: dict[str, Any]) -> None:
-        from pvcontrol import dependencies
+    async def _apply_controller_state(self, payload: dict[str, Any]) -> None:
+        import pvcontrol.api as api
 
         controller_state = payload.get("controller", {})
         if desired_mode := controller_state.get("desired_mode"):
             try:
-                dependencies.controller.set_desired_mode(ChargeMode(desired_mode))
+                await api.put_controller_desired_mode(ChargeMode(desired_mode))
                 logger.info(f"Restored desired_mode: {desired_mode}")
             except ValueError:
                 logger.warning(f"Ignoring invalid desired_mode from retained state: {desired_mode!r}")
         if phase_mode := controller_state.get("phase_mode"):
             try:
-                dependencies.controller.set_phase_mode(PhaseMode(phase_mode))
+                await api.put_controller_phase_mode(PhaseMode(phase_mode))
                 logger.info(f"Restored phase_mode: {phase_mode}")
             except ValueError:
                 logger.warning(f"Ignoring invalid phase_mode from retained state: {phase_mode!r}")
         if desired_priority := controller_state.get("desired_priority"):
             try:
-                dependencies.controller.set_desired_priority(Priority(desired_priority))
+                await api.put_controller_desired_priority(Priority(desired_priority))
                 logger.info(f"Restored desired_priority: {desired_priority}")
             except ValueError:
                 logger.warning(f"Ignoring invalid desired_priority from retained state: {desired_priority!r}")

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -140,56 +140,42 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("pvcontrol/status", mock_client.publish.call_args.args[0])
         self.assertEqual("offline", call_kwargs["payload"])
 
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_publish_state_converts_enums_to_names(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+        mock_client.publish.reset_mock()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "version": "1.0.0",
+            "meter": {"power_pv": 1000},
+            "wallbox": {"car_status": CarStatus.Charging, "wb_error": WbError.OK, "power": 3000},
+            "relay": {},
+            "controller": {},
+            "car": {},
+        }
+
+        with patch("pvcontrol.api.get_root", new_callable=AsyncMock, return_value=mock_response):
+            await self.publisher.publish_state()
+
+        mock_client.publish.assert_called_once()
+        call_kwargs = mock_client.publish.call_args.kwargs
+        payload = json.loads(call_kwargs["payload"])
+        self.assertEqual("Charging", payload["wallbox"]["car_status"])
+        self.assertEqual("OK", payload["wallbox"]["wb_error"])
+        self.assertTrue(call_kwargs["retain"])
+
     async def test_publish_state_without_connection_does_not_crash(self):
         self.publisher._client = None
         # Should not raise even without connection (reconnect also fails silently)
         with patch.object(self.publisher, "_try_reconnect", new_callable=AsyncMock):
             await self.publisher.publish_state()
-
-    def test_build_state_converts_int_enums(self):
-        deps = MagicMock()
-        deps.version = "1.0.0"
-
-        controller_data = MagicMock()
-        controller_data.mode = ChargeMode.PV_ONLY
-        controller_data.desired_mode = ChargeMode.PV_ONLY
-        controller_data.phase_mode = PhaseMode.AUTO
-        controller_data.priority = Priority.AUTO
-        controller_data.desired_priority = Priority.AUTO
-        controller_data.error = 0
-        deps.controller.get_data.return_value = controller_data
-
-        meter_data = MagicMock()
-        meter_data.power_pv = 3000.0
-        deps.meter.get_data.return_value = meter_data
-
-        wallbox_data = MagicMock()
-        wallbox_data.car_status = CarStatus.Charging
-        wallbox_data.wb_error = WbError.OK
-        deps.wallbox.get_data.return_value = wallbox_data
-
-        relay_data = MagicMock()
-        deps.relay.get_data.return_value = relay_data
-
-        car_data = MagicMock()
-        deps.car.get_data.return_value = car_data
-
-        with patch("pvcontrol.api.PvcontrolResponse") as mock_response_cls:
-            mock_response = MagicMock()
-            mock_response.model_dump.return_value = {
-                "version": "1.0.0",
-                "controller": {"mode": "PV_ONLY", "error": 0},
-                "meter": {"power_pv": 3000.0},
-                "wallbox": {"car_status": 2, "wb_error": 0},
-                "relay": {},
-                "car": {},
-            }
-            mock_response_cls.return_value = mock_response
-
-            state = self.publisher._build_state(deps)
-
-        self.assertEqual("Charging", state["wallbox"]["car_status"])
-        self.assertEqual("OK", state["wallbox"]["wb_error"])
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_lwt_configured(self, mock_client_cls: Any):
@@ -234,12 +220,16 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
 
         await self.publisher.start()
 
-        with patch("pvcontrol.dependencies.controller") as mock_controller:
+        with (
+            patch("pvcontrol.api.put_controller_desired_mode", new_callable=AsyncMock) as mock_mode,
+            patch("pvcontrol.api.put_controller_phase_mode", new_callable=AsyncMock) as mock_phase,
+            patch("pvcontrol.api.put_controller_desired_priority", new_callable=AsyncMock) as mock_prio,
+        ):
             await self.publisher.restore_state()
 
-        mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
-        mock_controller.set_phase_mode.assert_called_once_with(PhaseMode.CHARGE_1P)
-        mock_controller.set_desired_priority.assert_called_once_with(Priority.CAR)
+        mock_mode.assert_called_once_with(ChargeMode.PV_ONLY)
+        mock_phase.assert_called_once_with(PhaseMode.CHARGE_1P)
+        mock_prio.assert_called_once_with(Priority.CAR)
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_restore_state_timeout_does_not_crash(self, mock_client_cls: Any):

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -205,3 +205,61 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         will = call_kwargs["will"]
         self.assertEqual("pvcontrol/status", str(will.topic))
         self.assertEqual("offline", will.payload)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_restore_state_applies_retained_values(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client.unsubscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        retained_payload = json.dumps(
+            {
+                "controller": {
+                    "desired_mode": "PV_ONLY",
+                    "phase_mode": "CHARGE_1P",
+                    "desired_priority": "CAR",
+                }
+            }
+        )
+        mock_msg = MagicMock()
+        mock_msg.payload = retained_payload
+
+        messages_iter = AsyncMock()
+        messages_iter.__anext__ = AsyncMock(return_value=mock_msg)
+        mock_client.messages = messages_iter
+
+        await self.publisher.start()
+
+        with patch("pvcontrol.dependencies.controller") as mock_controller:
+            await self.publisher.restore_state()
+
+        mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
+        mock_controller.set_phase_mode.assert_called_once_with(PhaseMode.CHARGE_1P)
+        mock_controller.set_desired_priority.assert_called_once_with(Priority.CAR)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_restore_state_timeout_does_not_crash(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client.unsubscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        messages_iter = AsyncMock()
+        messages_iter.__anext__ = AsyncMock(side_effect=TimeoutError)
+        mock_client.messages = messages_iter
+
+        await self.publisher.start()
+        await self.publisher.restore_state()
+        # Should not raise — just logs and continues
+
+    async def test_restore_state_without_connection(self):
+        self.publisher._client = None
+        await self.publisher.restore_state()
+        # Should not raise


### PR DESCRIPTION
- allows charging to continue after pvcontrol restart or crash