### PR TITLE
Don't restore PhaseMode DISABLED from mqtt

### DIFF
--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -457,8 +457,9 @@ class MqttPublisher:
                 logger.warning(f"Ignoring invalid desired_mode from retained state: {desired_mode!r}")
         if phase_mode := controller_state.get("phase_mode"):
             try:
-                self._controller.set_phase_mode(PhaseMode(phase_mode))
-                logger.info(f"Restored phase_mode: {phase_mode}")
+                if phase_mode != PhaseMode.DISABLED:
+                    self._controller.set_phase_mode(PhaseMode(phase_mode))
+                    logger.info(f"Restored phase_mode: {phase_mode}")
             except ValueError:
                 logger.warning(f"Ignoring invalid phase_mode from retained state: {phase_mode!r}")
         if desired_priority := controller_state.get("desired_priority"):

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -259,3 +259,38 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         self.publisher._client = None
         await self.publisher.restore_state()
         # Should not raise
+
+    # Don't restore phase_mode if it's DISABLED. DISABLED is set only if phase switching relay is not available
+    # when pvcontrol was deployed on a node without it.
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_restore_state_ignore_disabled_phase_mode(self, mock_client_cls: Any):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client.unsubscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        retained_payload = json.dumps(
+            {
+                "controller": {
+                    "desired_mode": "PV_ONLY",
+                    "phase_mode": "DISABLED",
+                    "desired_priority": "CAR",
+                }
+            }
+        )
+        mock_msg = MagicMock()
+        mock_msg.payload = retained_payload
+
+        messages_iter = AsyncMock()
+        messages_iter.__anext__ = AsyncMock(return_value=mock_msg)
+        mock_client.messages = messages_iter
+
+        await self.publisher.start()
+        await self.publisher.restore_state()
+
+        self.mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
+        self.mock_controller.set_phase_mode.assert_not_called()
+        self.mock_controller.set_desired_priority.assert_called_once_with(Priority.CAR)


### PR DESCRIPTION
- DISABLED is applied only based on config and hardware
- with restore, PhaseMode stays on DISABLED once pvcontrol was moved to a node w/o phase switching relay