### PR TITLE
Fix #424: renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,6 @@
         "npm"
       ],
       "matchPackageNames": [
-        "**",
         "!/@angular.*/",
         "!typescript"
       ],


### PR DESCRIPTION
- can't have ** and exclude patterns in matchPackageNames