### PR TITLE
mqtt: wait up to 5 min for connection on startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+pv-control is an electric car charging controller for photovoltaic (PV) systems. It controls a go-e wallbox to charge an EV using solar power as efficiently as possible, with optional phase switching (1P/3P) via a GPIO relay on Raspberry Pi and vehicle SOC monitoring via the MySkoda API (Skoda cars).
+
+## Architecture
+
+**Python backend** (FastAPI + uvicorn):
+
+```
+pvcontrol/
+  __main__.py          # CLI entry point: parses args, runs uvicorn
+  app.py               # FastAPI app: lifespan (init/shutdown), static file serving, /metrics mount
+  api.py               # REST API routes under /api/pvcontrol/ (GET state, PUT mode/phase/priority)
+  service.py           # BaseService[C, D] — shared pattern for all services: config, data, error counter, Prometheus metrics
+  dependencies.py      # Global singleton initialization: creates relay → wallbox → meter → car → controller + schedulers
+  chargecontroller.py  # Core control loop: read meter/wallbox, calculate setpoints, control charging power and phase switching
+  meter.py             # Meter implementations: KostalMeter (Modbus TCP), SolarWattMeter (REST), SmaTripowerMeter (webconnect), SimulatedMeter, TestMeter
+  wallbox.py           # Wallbox implementations: GoeWallbox (REST/MQTT to go-e), SimulatedWallbox, SimulatedWallboxWithRelay
+  car.py               # Car implementations: SkodaCar (MySkoda API), SimulatedCar, NoCar
+  relay.py             # Phase relay: PhaseRelay base, DisabledPhaseRelay, SimulatedPhaseRelay, PhaseRelayFactory
+  raspi_relay.py       # Real GPIO relay driver (RPi.GPIO) — only loaded when configured and on Pi
+  scheduler.py         # Scheduler (threading.Timer), AsyncScheduler (asyncio.gather + sleep)
+  mqtt.py              # MQTT publisher with Home Assistant auto-discovery, state restore from retained messages
+  utils.py             # aiohttp trace config for debug logging
+```
+
+**Key patterns**:
+
+- Every hardware abstraction (meter, wallbox, car, relay) extends `BaseService[Config, Data]` with `read_data()`, error counting, and Prometheus Gauges.
+- Factory classes (`MeterFactory`, `WallboxFactory`, `CarFactory`, `PhaseRelayFactory`) instantiate the correct implementation from a type string.
+- `ChargeController.run()` is the core control loop, scheduled via `AsyncScheduler` at configurable cycle intervals (default 30s).
+- Global dependencies are resolved in `dependencies.init()` and stored as module-level variables in `dependencies.py`.
+- CLI args (`--meter`, `--wallbox`, `--relay`, `--car`, `--config JSON`) control which implementations are used — enabling simulation without code changes.
+
+**Charge modes**: OFF, MAX, MANUAL, PV_ONLY, PV_ALL
+**Priority modes**: AUTO (balance home battery vs car), HOME_BATTERY, CAR
+**Phase modes**: DISABLED, AUTO, CHARGE_1P, CHARGE_3P
+
+**Frontend**: Single-page Angular app (`ui/`), built to `ui/dist/ui/browser/`, served as static files by the FastAPI app. See [.github/instructions/angular.instructions.md](.github/instructions/angular.instructions.md) for Angular 20+ conventions (signals, standalone components, new control flow, `input()`/`output()` APIs).
+
+## Development Commands
+
+All Python commands use `uv run`. Install with `make install` (runs `uv sync` + `npm install` in ui/).
+
+| Task | Command |
+|------|---------|
+| Install deps | `make install` or `uv sync --all-extras` |
+| Run app locally | `uv run -m pvcontrol` |
+| Run with auto-reload | `uv run uvicorn pvcontrol.app:app --port 8080 --reload --reload-dir ./pvcontrol` |
+| Lint (Python) | `make lint` → `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` |
+| Lint (UI) | `make lint` → `(cd ui && ng lint)` |
+| Type check | `uv run ty check` |
+| Run Python tests | `uv run python -m unittest discover -v -s tests` or `make test` |
+| Build UI | `(cd ui && ng build --configuration production)` |
+| Build package | `make build` or `uv build` |
+| Full dev cycle | `make` (default: install + lint + test) |
+| Clean | `make clean` |
+| Upgrade deps | `make upgrade` or `uv sync --upgrade --all-extras --dev` |
+
+## Testing
+
+Tests are standard Python `unittest` in `tests/`, one file per module:
+
+- `test_api.py`, `test_app.py` — API endpoint and app lifespan tests
+- `test_chargecontroller.py` — core control loop logic (most complex test file)
+- `test_meter.py`, `test_wallbox.py`, `test_car.py`, `test_relay.py` — service implementations
+- `test_mqtt.py` — MQTT publishing and state restore
+- `test_scheduler.py` — scheduler behavior
+
+Use `TestMeter` (from `meter.py`) in tests to set PV/home power/SOC values directly. Use `SimulatedWallbox.set_car_status()` and `set_wb_error()` for controlled testing.
+
+## Configuration
+
+Configuration is JSON passed via `--config` or service file. The structure maps to component types:
+
+```json
+{
+  "meter": { "host": "scb.fritz.box", ... },
+  "wallbox": { "url": "http://go-echarger.fritz.box", ... },
+  "relay": { "enable_phase_switching": true, "installed_on_host": "..." },
+  "car": { "user": "...", "password": "...", "vin": "...", ... },
+  "controller": { "cycle_time": 30, "line_voltage": 230, ... },
+  "mqtt": { "broker": "localhost", "port": 1883, ... }
+}
+```
+
+Config dataclasses live in each module: `ChargeControllerConfig` (chargecontroller.py), `*MeterConfig` (meter.py), `WallboxConfig`/`GoeWallboxConfig` (wallbox.py), `CarConfig`/`SkodaCarConfig` (car.py), `PhaseRelayConfig` (relay.py), `MqttConfig` (mqtt.py).
+
+## Deployment
+
+- **Raspberry Pi**: systemd service (`pvcontrol.service`) behind nginx (`pvcontrol.nginx`)
+- **k8s**: Docker image built via GitHub Actions, published to `ghcr.io/stephanme/pv-control`
+- **Docker**: `docker build -t stephanme/pv-control .` (multi-stage, Python 3.14)
+- Uses `uv` for dependency management and building (see `pyproject.toml`, `uv.lock`)
+
+## Key constraints
+
+- Python >= 3.14 required
+- RPi.GPIO only available on Linux ARM — guarded by runtime check and lazy import
+- Line length: 140 chars (ruff config)
+- `ty` (Python 3.14's type checker) is used for type checking instead of pyright/mypy
+- `ruff` for linting + formatting; `httpx` in dev deps for API testing
+- Prometheus metrics are module-level globals with `pvcontrol_` prefix

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -3,6 +3,8 @@ import dataclasses
 import enum
 import json
 import logging
+import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -316,15 +318,19 @@ class MqttPublisher:
         self._car = car
         self._client: aiomqtt.Client | None = None
         self._next_reconnect_at: float = 0
+        self._client_id: str = uuid.uuid4().hex[:8]
+        # Retry window (seconds) for the initial connect; tests set it to 0 to disable retrying.
+        self._retry_window_s: float = 300
 
-    async def start(self) -> None:
+    async def _connect_once(self) -> bool:
+        """Attempt a single connection. Returns True on success, False on failure."""
         try:
             self._client = aiomqtt.Client(
                 hostname=self._config.broker,
                 port=self._config.port,
                 username=self._config.username or None,
                 password=self._config.password or None,
-                identifier="pvcontrol",
+                identifier=f"pvcontrol-{self._client_id}",
                 will=aiomqtt.Will(
                     topic=f"{self._config.topic_prefix}/status",
                     payload="offline",
@@ -335,10 +341,22 @@ class MqttPublisher:
             await self._client.publish(f"{self._config.topic_prefix}/status", payload="online", retain=True)
             await self._publish_discovery()
             self._next_reconnect_at = 0
-            logger.info(f"MQTT connected to {self._config.broker}:{self._config.port}")
+            logger.info("MQTT connected to %s:%d", self._config.broker, self._config.port)
+            return True
         except Exception:
-            logger.exception("MQTT connection failed")
             await self._disconnect()
+            return False
+
+    async def start(self) -> None:
+        """Connect to the broker, retrying failed attempts until the retry window expires."""
+        deadline = time.time() + self._retry_window_s
+        while not await self._connect_once():
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                logger.error("MQTT connection failed after %.0fs retry window", self._retry_window_s)
+                return
+            logger.warning("MQTT connection attempt failed, %.0fs remaining of retry window", remaining)
+            await asyncio.sleep(min(remaining, 10))
 
     async def stop(self) -> None:
         if self._client:
@@ -419,13 +437,11 @@ class MqttPublisher:
             await self._client.publish(topic, payload=json.dumps(payload), retain=True)
 
     async def _try_reconnect(self) -> None:
-        import time
-
-        now = time.monotonic()
+        now = time.time()
         if now < self._next_reconnect_at:
             return
         self._next_reconnect_at = now + 60
-        await self.start()
+        await self._connect_once()
 
     async def restore_state(self) -> None:
         if self._client is None:

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -141,8 +141,44 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         mock_client.__aenter__ = AsyncMock(side_effect=OSError("Connection refused"))
         mock_client_cls.return_value = mock_client
 
+        self.publisher._retry_window_s = 0  # skip retry loop immediately
         await self.publisher.start()
         self.assertIsNone(self.publisher._client)
+
+    @patch("pvcontrol.mqtt.asyncio.sleep", new_callable=AsyncMock)
+    @patch("pvcontrol.mqtt.time.time")
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_start_retry_exhaustion_logs_error(self, mock_client_cls: Any, mock_time: MagicMock, mock_sleep: AsyncMock):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(side_effect=OSError("Connection refused"))
+        mock_client_cls.return_value = mock_client
+
+        # Drive the clock: set deadline at t=0, allow one retry at t=0, then jump past the window.
+        mock_time.side_effect = [0.0, 0.0, 100.0]
+        self.publisher._retry_window_s = 60
+
+        with self.assertLogs("pvcontrol.mqtt", level="ERROR") as logs:
+            await self.publisher.start()
+
+        self.assertIsNone(self.publisher._client)
+        self.assertEqual(mock_client_cls.call_count, 2)  # initial attempt + one retry
+        mock_sleep.assert_awaited_once()
+        self.assertTrue(any("retry window" in msg for msg in logs.output))
+
+    @patch("pvcontrol.mqtt.asyncio.sleep", new_callable=AsyncMock)
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_start_eventually_succeeds(self, mock_client_cls: Any, mock_sleep: AsyncMock):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        # First call fails, second call succeeds
+        mock_client.__aenter__.side_effect = [OSError("Connection refused"), mock_client]
+        await self.publisher.start()
+        self.assertIsNotNone(self.publisher._client)
+        self.assertEqual(mock_client_cls.call_count, 2)
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_stop_publishes_offline(self, mock_client_cls: Any):


### PR DESCRIPTION
- time needed until mosquitto is running again after node draining
- addresses state loss when pvcontrol and mosquitto were running on same node