### PR TITLE
feat(mqtt): add MQTT control via Home Assistant select entities

### DIFF
--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -15,6 +16,7 @@ from pvcontrol.car import Car
 from pvcontrol.chargecontroller import ChargeController, ChargeMode, PhaseMode, Priority
 from pvcontrol.meter import Meter
 from pvcontrol.relay import PhaseRelay
+from pvcontrol.scheduler import AsyncScheduler
 from pvcontrol.wallbox import CarStatus, Wallbox, WbError
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,8 @@ class EntityDef:
     unit_of_measurement: str | None = None
     entity_category: str | None = None
     options: list[str] = field(default_factory=list)
+    command_topic: str | None = None
+    handler: Callable[[ChargeController, str], None] | None = None
 
 
 ENTITY_DEFINITIONS: list[EntityDef] = [
@@ -187,20 +191,26 @@ ENTITY_DEFINITIONS: list[EntityDef] = [
         options=[m.value for m in ChargeMode],
     ),
     EntityDef(
-        "sensor",
+        "select",
         "controller_desired_mode",
         "Desired Charge Mode",
         "{{ value_json.controller.desired_mode }}",
         device_class="enum",
         options=[m.value for m in ChargeMode],
+        command_topic="controller/desired_mode/set",
+        handler=lambda c, v: _validate_enum_and_set(v, ChargeMode, c.set_desired_mode, "controller/desired_mode/set"),
     ),
     EntityDef(
-        "sensor",
+        "select",
         "controller_phase_mode",
         "Phase Mode",
         "{{ value_json.controller.phase_mode }}",
         device_class="enum",
         options=[m.value for m in PhaseMode],
+        command_topic="controller/phase_mode/set",
+        handler=lambda c, v: _validate_enum_and_set(
+            v, PhaseMode, c.set_phase_mode, "controller/phase_mode/set", lambda m: m != PhaseMode.DISABLED
+        ),
     ),
     EntityDef(
         "sensor",
@@ -211,12 +221,14 @@ ENTITY_DEFINITIONS: list[EntityDef] = [
         options=[m.value for m in Priority],
     ),
     EntityDef(
-        "sensor",
+        "select",
         "controller_desired_priority",
         "Desired Priority",
         "{{ value_json.controller.desired_priority }}",
         device_class="enum",
         options=[m.value for m in Priority],
+        command_topic="controller/desired_priority/set",
+        handler=lambda c, v: _validate_enum_and_set(v, Priority, c.set_desired_priority, "controller/desired_priority/set"),
     ),
     # Car
     EntityDef(
@@ -290,6 +302,32 @@ ENTITY_DEFINITIONS: list[EntityDef] = [
 ]
 
 
+def _validate_enum_and_set(
+    value_str: str,
+    enum_cls: type[enum.Enum],
+    setter: Callable[[Any], None],
+    log_prefix: str,
+    filter_fn: Callable[[enum.Enum], bool] | None = None,
+) -> None:
+    """Validate string as enum, apply optional filter, and call setter."""
+    try:
+        value = enum_cls(value_str)
+    except ValueError:
+        logger.warning("Invalid %s value: %r", log_prefix, value_str)
+        return
+    if filter_fn is not None and not filter_fn(value):
+        logger.info("Ignoring %s for %s (filtered)", value, log_prefix)
+        return
+    setter(value)
+
+
+# Command topic handlers for live MQTT commands and state restore
+# Maps command topic (e.g., "controller/desired_mode/set") to handler function
+_COMMAND_HANDLERS: dict[str, Callable[[ChargeController, str], None]] = {
+    e.command_topic: e.handler for e in ENTITY_DEFINITIONS if e.command_topic and e.handler
+}
+
+
 def _json_default(o: Any) -> Any:
     if isinstance(o, datetime):
         return o.isoformat()
@@ -319,6 +357,12 @@ class MqttPublisher:
         self._client: aiomqtt.Client | None = None
         self._next_reconnect_at: float = 0
         self._client_id: str = uuid.uuid4().hex[:8]
+        self._connected = asyncio.Event()  # signals when client is connected
+        # Use module-level command handlers (single source of truth)
+        self._command_handlers = _COMMAND_HANDLERS
+        # Internal message handler scheduler, minor interval to avoid CPU starvation when mqtt broker is not available
+        # _message_handler waits for incoming messages and dispatches them to the appropriate command handler
+        self._message_scheduler = AsyncScheduler(0.1, self._message_handler)
         # Retry window (seconds) for the initial connect; tests set it to 0 to disable retrying.
         self._retry_window_s: float = 300
 
@@ -340,7 +384,11 @@ class MqttPublisher:
             await self._client.__aenter__()
             await self._client.publish(f"{self._config.topic_prefix}/status", payload="online", retain=True)
             await self._publish_discovery()
+            # Subscribe to command topics for MQTT control
+            for topic in self._command_handlers:
+                await self._client.subscribe(f"{self._config.topic_prefix}/{topic}")
             self._next_reconnect_at = 0
+            self._connected.set()  # Signal that we're connected
             logger.info("MQTT connected to %s:%d", self._config.broker, self._config.port)
             return True
         except Exception:
@@ -357,8 +405,13 @@ class MqttPublisher:
                 return
             logger.warning("MQTT connection attempt failed, %.0fs remaining of retry window", remaining)
             await asyncio.sleep(min(remaining, 10))
+        # Start message handler scheduler after successful connection
+        await self._message_scheduler.start()
 
     async def stop(self) -> None:
+        # Stop message handler scheduler
+        await self._message_scheduler.stop()
+
         if self._client:
             try:
                 await self._client.publish(f"{self._config.topic_prefix}/status", payload="offline", retain=True)
@@ -386,7 +439,7 @@ class MqttPublisher:
             payload = json.dumps(state, default=_json_default)
             await self._client.publish(f"{self._config.topic_prefix}/state", payload=payload, retain=True)
         except aiomqtt.MqttError as e:
-            logger.warning(f"MQTT publish failed: {e}")
+            logger.warning("MQTT publish failed: %s", e)
             await self._disconnect()
         except Exception:
             logger.exception("MQTT publish error")
@@ -398,6 +451,7 @@ class MqttPublisher:
             except Exception:
                 pass
             self._client = None
+        self._connected.clear()  # Signal that we're disconnected
 
     async def _publish_discovery(self) -> None:
         if self._client is None:
@@ -434,6 +488,8 @@ class MqttPublisher:
                 payload["entity_category"] = entity.entity_category
             if entity.options:
                 payload["options"] = entity.options
+            if entity.command_topic:
+                payload["command_topic"] = f"{self._config.topic_prefix}/{entity.command_topic}"
             await self._client.publish(topic, payload=json.dumps(payload), retain=True)
 
     async def _try_reconnect(self) -> None:
@@ -442,6 +498,32 @@ class MqttPublisher:
             return
         self._next_reconnect_at = now + 60
         await self._connect_once()
+
+    async def _message_handler(self) -> None:
+        """Handle incoming MQTT command messages."""
+        # Wait until connected
+        await self._connected.wait()
+        assert self._client is not None  # _connected.set() only called after successful connect
+        # Hoist prefix computation outside the hot loop
+        prefix = f"{self._config.topic_prefix}/"
+        prefix_len = len(prefix)
+        try:
+            async for msg in self._client.messages:
+                topic = str(msg.topic)
+                payload = msg.payload.decode() if isinstance(msg.payload, bytes) else str(msg.payload)
+                logger.info("Received MQTT command: %s = %s", topic, payload)
+
+                # Extract topic suffix (after prefix/)
+                if topic.startswith(prefix):
+                    topic_suffix = topic[prefix_len:]
+                    handler = self._command_handlers.get(topic_suffix)
+                    if handler:
+                        handler(self._controller, payload)
+        except asyncio.CancelledError:
+            logger.debug("MQTT message handler cancelled")
+            raise
+        except Exception:
+            logger.exception("MQTT message handler error")
 
     async def restore_state(self) -> None:
         if self._client is None:
@@ -465,22 +547,9 @@ class MqttPublisher:
 
     def _apply_controller_state(self, payload: dict[str, Any]) -> None:
         controller_state = payload.get("controller", {})
-        if desired_mode := controller_state.get("desired_mode"):
-            try:
-                self._controller.set_desired_mode(ChargeMode(desired_mode))
-                logger.info(f"Restored desired_mode: {desired_mode}")
-            except ValueError:
-                logger.warning(f"Ignoring invalid desired_mode from retained state: {desired_mode!r}")
-        if phase_mode := controller_state.get("phase_mode"):
-            try:
-                if phase_mode != PhaseMode.DISABLED:
-                    self._controller.set_phase_mode(PhaseMode(phase_mode))
-                    logger.info(f"Restored phase_mode: {phase_mode}")
-            except ValueError:
-                logger.warning(f"Ignoring invalid phase_mode from retained state: {phase_mode!r}")
-        if desired_priority := controller_state.get("desired_priority"):
-            try:
-                self._controller.set_desired_priority(Priority(desired_priority))
-                logger.info(f"Restored desired_priority: {desired_priority}")
-            except ValueError:
-                logger.warning(f"Ignoring invalid desired_priority from retained state: {desired_priority!r}")
+        for key, value_str in controller_state.items():
+            topic = f"controller/{key}/set"
+            handler = _COMMAND_HANDLERS.get(topic)
+            if handler:
+                handler(self._controller, value_str)
+                logger.info("Restored %s: %s", key, value_str)

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import unittest
 from typing import Any, final, override
@@ -34,7 +35,7 @@ class MqttConfigTest(unittest.TestCase):
 class EntityDefinitionsTest(unittest.TestCase):
     def test_all_entities_have_required_fields(self):
         for entity in ENTITY_DEFINITIONS:
-            self.assertIn(entity.component, ("sensor", "binary_sensor"))
+            self.assertIn(entity.component, ("sensor", "binary_sensor", "select"))
             self.assertTrue(entity.object_id)
             self.assertTrue(entity.name)
             self.assertTrue(entity.value_template)
@@ -330,3 +331,274 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         self.mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
         self.mock_controller.set_phase_mode.assert_not_called()
         self.mock_controller.set_desired_priority.assert_called_once_with(Priority.CAR)
+
+
+@final
+class EntityDefinitionsSelectTest(unittest.TestCase):
+    """Tests for the new select entities for MQTT control."""
+
+    def test_select_entities_exist_and_have_command_topic(self):
+        """Verify the three select entities are defined."""
+        select_entities = [e for e in ENTITY_DEFINITIONS if e.component == "select"]
+        self.assertEqual(len(select_entities), 3)
+
+        object_ids = {e.object_id for e in select_entities}
+        self.assertIn("controller_desired_mode", object_ids)
+        self.assertIn("controller_phase_mode", object_ids)
+        self.assertIn("controller_desired_priority", object_ids)
+        for entity in select_entities:
+            self.assertIsNotNone(entity.command_topic, f"{entity.object_id} missing command_topic")
+            assert entity.command_topic is not None
+            self.assertTrue(entity.command_topic.startswith("controller/"))
+
+    def test_desired_mode_select_options(self):
+        """Desired mode select should have all ChargeMode values as options."""
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "controller_desired_mode")
+        self.assertEqual(entity.options, [m.value for m in ChargeMode])
+        self.assertEqual(entity.command_topic, "controller/desired_mode/set")
+
+    def test_phase_mode_select_options(self):
+        """Phase mode select should have all PhaseMode values as options."""
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "controller_phase_mode")
+        self.assertEqual(entity.options, [m.value for m in PhaseMode])
+        self.assertEqual(entity.command_topic, "controller/phase_mode/set")
+
+    def test_desired_priority_select_options(self):
+        """Desired priority select should have all Priority values as options."""
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "controller_desired_priority")
+        self.assertEqual(entity.options, [m.value for m in Priority])
+        self.assertEqual(entity.command_topic, "controller/desired_priority/set")
+
+
+@final
+class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
+    """Tests for MQTT command handling functionality."""
+
+    @override
+    def setUp(self):
+        self.config = MqttConfig(broker="testhost", port=1883)
+        self.mock_controller = MagicMock()
+        self.mock_meter = MagicMock()
+        self.mock_wallbox = MagicMock()
+        self.mock_relay = MagicMock()
+        self.mock_car = MagicMock()
+        self.mock_controller.get_data.return_value = ChargeControllerData()
+        self.mock_meter.get_data.return_value = MeterData()
+        self.mock_wallbox.get_data.return_value = WallboxData()
+        self.mock_relay.get_data.return_value = PhaseRelayData()
+        self.mock_car.get_data.return_value = CarData()
+        self.publisher = MqttPublisher(
+            self.config,
+            "1.0.0",
+            controller=self.mock_controller,
+            meter=self.mock_meter,
+            wallbox=self.mock_wallbox,
+            relay=self.mock_relay,
+            car=self.mock_car,
+        )
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_start_subscribes_to_command_topics(self, mock_client_cls: Any):
+        """Verify command topics are subscribed on connect."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+
+        # Should subscribe to all 3 command topics
+        expected_topics = [
+            "pvcontrol/controller/desired_mode/set",
+            "pvcontrol/controller/phase_mode/set",
+            "pvcontrol/controller/desired_priority/set",
+        ]
+        subscribed_topics = [call.args[0] for call in mock_client.subscribe.call_args_list]
+        for topic in expected_topics:
+            self.assertIn(topic, subscribed_topics, f"Topic {topic} not subscribed")
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_discovery_includes_command_topic_for_select(self, mock_client_cls: Any):
+        """Discovery payload for select entities should include command_topic."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+
+        # Find select entity discovery calls
+        select_discovery_calls = []
+        for call in mock_client.publish.call_args_list[1:]:  # skip online status
+            topic = call.args[0] if call.args else call.kwargs.get("topic", "")
+            if "/select/" in topic:
+                payload_str = call.kwargs.get("payload") or call.args[1]
+                payload = json.loads(payload_str)
+                select_discovery_calls.append(payload)
+
+        self.assertEqual(len(select_discovery_calls), 3)
+        for payload in select_discovery_calls:
+            self.assertIn("command_topic", payload)
+            self.assertTrue(payload["command_topic"].startswith("pvcontrol/controller/"))
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_message_handler_sets_desired_mode(self, mock_client_cls: Any):
+        """Message handler should call set_desired_mode for desired_mode command."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        # Simulate receiving a message on the desired_mode command topic
+        async def mock_messages():
+            # First yield simulates the restore_state message (if any), then our command
+            yield MagicMock(payload=b'{"controller": {"desired_mode": "OFF"}}', topic="pvcontrol/state")
+            yield MagicMock(payload=b"PV_ONLY", topic="pvcontrol/controller/desired_mode/set")
+
+        mock_client.messages = mock_messages()
+
+        await self.publisher.start()
+        # Give message handler time to process
+        await asyncio.sleep(0.01)
+
+        self.mock_controller.set_desired_mode.assert_called_with(ChargeMode.PV_ONLY)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_message_handler_sets_phase_mode(self, mock_client_cls: Any):
+        """Message handler should call set_phase_mode for phase_mode command."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        async def mock_messages():
+            yield MagicMock(payload=b'{"controller": {"phase_mode": "AUTO"}}', topic="pvcontrol/state")
+            yield MagicMock(payload=b"CHARGE_1P", topic="pvcontrol/controller/phase_mode/set")
+
+        mock_client.messages = mock_messages()
+
+        await self.publisher.start()
+        await asyncio.sleep(0.01)
+
+        self.mock_controller.set_phase_mode.assert_called_with(PhaseMode.CHARGE_1P)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_message_handler_sets_desired_priority(self, mock_client_cls: Any):
+        """Message handler should call set_desired_priority for desired_priority command."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        async def mock_messages():
+            yield MagicMock(payload=b'{"controller": {"desired_priority": "AUTO"}}', topic="pvcontrol/state")
+            yield MagicMock(payload=b"CAR", topic="pvcontrol/controller/desired_priority/set")
+
+        mock_client.messages = mock_messages()
+
+        await self.publisher.start()
+        await asyncio.sleep(0.01)
+
+        self.mock_controller.set_desired_priority.assert_called_with(Priority.CAR)
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_message_handler_ignores_disabled_phase_mode(self, mock_client_cls: Any):
+        """Message handler should ignore DISABLED phase_mode (consistent with restore_state)."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        async def mock_messages():
+            yield MagicMock(payload=b"DISABLED", topic="pvcontrol/controller/phase_mode/set")
+
+        mock_client.messages = mock_messages()
+
+        await self.publisher.start()
+        await asyncio.sleep(0.01)
+
+        self.mock_controller.set_phase_mode.assert_not_called()
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_message_handler_invalid_value_logs_warning(self, mock_client_cls: Any):
+        """Message handler should log warning for invalid enum values."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        async def mock_messages():
+            yield MagicMock(payload=b"INVALID_MODE", topic="pvcontrol/controller/desired_mode/set")
+
+        mock_client.messages = mock_messages()
+
+        with self.assertLogs("pvcontrol.mqtt", level="WARNING") as logs:
+            await self.publisher.start()
+            await asyncio.sleep(0.01)
+
+        # Log includes the full topic suffix as prefix
+        self.assertTrue(any("Invalid controller/desired_mode/set value" in msg for msg in logs.output))
+        self.mock_controller.set_desired_mode.assert_not_called()
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_stop_cancels_message_handler(self, mock_client_cls: Any):
+        """Stop should cancel the message handler scheduler."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.publish = AsyncMock()
+        mock_client.subscribe = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await self.publisher.start()
+        self.assertTrue(self.publisher._message_scheduler.is_started())
+
+        await self.publisher.stop()
+
+        self.assertFalse(self.publisher._message_scheduler.is_started())
+
+    @patch("pvcontrol.mqtt.aiomqtt.Client")
+    async def test_reconnect_restarts_message_handler(self, mock_client_cls: Any):
+        """Message handler should restart after reconnection."""
+        # Create two different mock clients to simulate disconnect/reconnect
+        mock_client1 = AsyncMock()
+        mock_client1.__aenter__ = AsyncMock(return_value=mock_client1)
+        mock_client1.__aexit__ = AsyncMock(return_value=None)
+        mock_client1.publish = AsyncMock()
+        mock_client1.subscribe = AsyncMock()
+        mock_client1.messages = AsyncMock()  # empty async iterator
+
+        mock_client2 = AsyncMock()
+        mock_client2.__aenter__ = AsyncMock(return_value=mock_client2)
+        mock_client2.__aexit__ = AsyncMock(return_value=None)
+        mock_client2.publish = AsyncMock()
+        mock_client2.subscribe = AsyncMock()
+        mock_client2.messages = AsyncMock()
+
+        # First call returns client1, second returns client2
+        mock_client_cls.side_effect = [mock_client1, mock_client2]
+
+        await self.publisher.start()
+        self.assertTrue(self.publisher._message_scheduler.is_started())
+
+        # Simulate disconnection and reconnection
+        self.publisher._client = None
+        self.publisher._next_reconnect_at = 0  # Force immediate retry
+
+        await self.publisher._try_reconnect()
+
+        # Scheduler should still be running (same task, but coroutine will run again on reconnect)
+        self.assertTrue(self.publisher._message_scheduler.is_started())


### PR DESCRIPTION
Add MQTT command topics to allow Home Assistant (or any MQTT client) to set charge controller parameters, mirroring the existing REST API PUT endpoints.