### PR TITLE
fix(mqtt): restore state on startup and simplify message handling

### DIFF
--- a/pvcontrol/dependencies.py
+++ b/pvcontrol/dependencies.py
@@ -50,7 +50,6 @@ async def init(args: Namespace, config: dict[str, Any]) -> None:
         mqtt_config = MqttConfig(**config["mqtt"])
         mqtt_publisher = MqttPublisher(mqtt_config, version, controller=controller, meter=meter, wallbox=wallbox, relay=relay, car=car)
         await mqtt_publisher.start()
-        await mqtt_publisher.restore_state()
         mqtt_scheduler = AsyncScheduler(controller.get_config().cycle_time, mqtt_publisher.publish_state)
         await mqtt_scheduler.start()
 

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -16,7 +17,6 @@ from pvcontrol.car import Car
 from pvcontrol.chargecontroller import ChargeController, ChargeMode, PhaseMode, Priority
 from pvcontrol.meter import Meter
 from pvcontrol.relay import PhaseRelay
-from pvcontrol.scheduler import AsyncScheduler
 from pvcontrol.wallbox import CarStatus, Wallbox, WbError
 
 logger = logging.getLogger(__name__)
@@ -358,11 +358,13 @@ class MqttPublisher:
         self._next_reconnect_at: float = 0
         self._client_id: str = uuid.uuid4().hex[:8]
         self._connected = asyncio.Event()  # signals when client is connected
+        self._retained_state: dict[str, Any] | None = None
+        self._state_received = asyncio.Event()  # signals when retained state message received
+        self._state_restore_timeout_s: float = 2.0  # tests can set to 0 to skip waiting
         # Use module-level command handlers (single source of truth)
         self._command_handlers = _COMMAND_HANDLERS
-        # Internal message handler scheduler, minor interval to avoid CPU starvation when mqtt broker is not available
-        # _message_handler waits for incoming messages and dispatches them to the appropriate command handler
-        self._message_scheduler = AsyncScheduler(0.1, self._message_handler)
+        # Message handler runs as background task after connection
+        self._message_task: asyncio.Task | None = None
         # Retry window (seconds) for the initial connect; tests set it to 0 to disable retrying.
         self._retry_window_s: float = 300
 
@@ -405,12 +407,33 @@ class MqttPublisher:
                 return
             logger.warning("MQTT connection attempt failed, %.0fs remaining of retry window", remaining)
             await asyncio.sleep(min(remaining, 10))
-        # Start message handler scheduler after successful connection
-        await self._message_scheduler.start()
+        # Subscribe to state topic BEFORE starting message handler to catch retained message
+        if self._client:
+            await self._client.subscribe(f"{self._config.topic_prefix}/state")
+        # Start message handler as background task
+        self._message_task = asyncio.create_task(self._message_handler())
+        # Wait for retained state message (configurable timeout; 0 = skip waiting)
+        if self._state_restore_timeout_s > 0:
+            try:
+                await asyncio.wait_for(self._state_received.wait(), timeout=self._state_restore_timeout_s)
+                if self._retained_state is not None:
+                    self._apply_controller_state(self._retained_state)
+            except TimeoutError:
+                logger.info("No retained MQTT state found, starting with defaults")
+        # Unsubscribe from state topic - we only needed it for the retained message at startup
+        if self._client:
+            try:
+                await self._client.unsubscribe(f"{self._config.topic_prefix}/state")
+            except Exception:
+                logger.debug("Failed to unsubscribe from state topic")
 
     async def stop(self) -> None:
-        # Stop message handler scheduler
-        await self._message_scheduler.stop()
+        # Stop message handler task
+        if self._message_task:
+            self._message_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._message_task
+            self._message_task = None
 
         if self._client:
             try:
@@ -497,7 +520,13 @@ class MqttPublisher:
         if now < self._next_reconnect_at:
             return
         self._next_reconnect_at = now + 60
-        await self._connect_once()
+        if await self._connect_once():
+            # Restart message handler after successful reconnection
+            if self._message_task and not self._message_task.done():
+                self._message_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self._message_task
+            self._message_task = asyncio.create_task(self._message_handler())
 
     async def _message_handler(self) -> None:
         """Handle incoming MQTT command messages."""
@@ -507,13 +536,24 @@ class MqttPublisher:
         # Hoist prefix computation outside the hot loop
         prefix = f"{self._config.topic_prefix}/"
         prefix_len = len(prefix)
+        state_topic = f"{self._config.topic_prefix}/state"
         try:
             async for msg in self._client.messages:
                 topic = str(msg.topic)
                 payload = msg.payload.decode() if isinstance(msg.payload, bytes) else str(msg.payload)
                 logger.info("Received MQTT command: %s = %s", topic, payload)
 
-                # Extract topic suffix (after prefix/)
+                # Handle retained state message for startup restore
+                if topic == state_topic:
+                    try:
+                        self._retained_state = json.loads(payload)
+                    except json.JSONDecodeError:
+                        logger.warning("Failed to parse retained state payload: %s", payload)
+                    # Signal that retained state was received
+                    self._state_received.set()
+                    continue  # Don't process state topic as command
+
+                # Extract topic suffix (after prefix/) for command topics
                 if topic.startswith(prefix):
                     topic_suffix = topic[prefix_len:]
                     handler = self._command_handlers.get(topic_suffix)
@@ -524,26 +564,6 @@ class MqttPublisher:
             raise
         except Exception:
             logger.exception("MQTT message handler error")
-
-    async def restore_state(self) -> None:
-        if self._client is None:
-            return
-        topic = f"{self._config.topic_prefix}/state"
-        try:
-            await self._client.subscribe(topic)
-            msg = await asyncio.wait_for(anext(self._client.messages), timeout=2.0)
-            payload = json.loads(msg.payload)
-            self._apply_controller_state(payload)
-        except TimeoutError:
-            logger.info("No retained MQTT state found, starting with defaults")
-        except Exception:
-            logger.exception("Failed to restore state from MQTT")
-        finally:
-            try:
-                if self._client is not None:
-                    await self._client.unsubscribe(topic)
-            except Exception:
-                pass
 
     def _apply_controller_state(self, payload: dict[str, Any]) -> None:
         controller_state = payload.get("controller", {})

--- a/pvcontrol/mqtt.py
+++ b/pvcontrol/mqtt.py
@@ -302,6 +302,14 @@ ENTITY_DEFINITIONS: list[EntityDef] = [
 ]
 
 
+def _json_default(o: Any) -> Any:
+    if isinstance(o, datetime):
+        return o.isoformat()
+    if isinstance(o, enum.Enum):
+        return o.value
+    raise TypeError(repr(o))
+
+
 def _validate_enum_and_set(
     value_str: str,
     enum_cls: type[enum.Enum],
@@ -326,14 +334,6 @@ def _validate_enum_and_set(
 _COMMAND_HANDLERS: dict[str, Callable[[ChargeController, str], None]] = {
     e.command_topic: e.handler for e in ENTITY_DEFINITIONS if e.command_topic and e.handler
 }
-
-
-def _json_default(o: Any) -> Any:
-    if isinstance(o, datetime):
-        return o.isoformat()
-    if isinstance(o, enum.Enum):
-        return o.value
-    raise TypeError(repr(o))
 
 
 class MqttPublisher:
@@ -367,35 +367,6 @@ class MqttPublisher:
         self._message_task: asyncio.Task | None = None
         # Retry window (seconds) for the initial connect; tests set it to 0 to disable retrying.
         self._retry_window_s: float = 300
-
-    async def _connect_once(self) -> bool:
-        """Attempt a single connection. Returns True on success, False on failure."""
-        try:
-            self._client = aiomqtt.Client(
-                hostname=self._config.broker,
-                port=self._config.port,
-                username=self._config.username or None,
-                password=self._config.password or None,
-                identifier=f"pvcontrol-{self._client_id}",
-                will=aiomqtt.Will(
-                    topic=f"{self._config.topic_prefix}/status",
-                    payload="offline",
-                    retain=True,
-                ),
-            )
-            await self._client.__aenter__()
-            await self._client.publish(f"{self._config.topic_prefix}/status", payload="online", retain=True)
-            await self._publish_discovery()
-            # Subscribe to command topics for MQTT control
-            for topic in self._command_handlers:
-                await self._client.subscribe(f"{self._config.topic_prefix}/{topic}")
-            self._next_reconnect_at = 0
-            self._connected.set()  # Signal that we're connected
-            logger.info("MQTT connected to %s:%d", self._config.broker, self._config.port)
-            return True
-        except Exception:
-            await self._disconnect()
-            return False
 
     async def start(self) -> None:
         """Connect to the broker, retrying failed attempts until the retry window expires."""
@@ -467,6 +438,48 @@ class MqttPublisher:
         except Exception:
             logger.exception("MQTT publish error")
 
+    async def _connect_once(self) -> bool:
+        """Attempt a single connection. Returns True on success, False on failure."""
+        try:
+            self._client = aiomqtt.Client(
+                hostname=self._config.broker,
+                port=self._config.port,
+                username=self._config.username or None,
+                password=self._config.password or None,
+                identifier=f"pvcontrol-{self._client_id}",
+                will=aiomqtt.Will(
+                    topic=f"{self._config.topic_prefix}/status",
+                    payload="offline",
+                    retain=True,
+                ),
+            )
+            await self._client.__aenter__()
+            await self._client.publish(f"{self._config.topic_prefix}/status", payload="online", retain=True)
+            await self._publish_discovery()
+            # Subscribe to command topics for MQTT control
+            for topic in self._command_handlers:
+                await self._client.subscribe(f"{self._config.topic_prefix}/{topic}")
+            self._next_reconnect_at = 0
+            self._connected.set()  # Signal that we're connected
+            logger.info("MQTT connected to %s:%d", self._config.broker, self._config.port)
+            return True
+        except Exception:
+            await self._disconnect()
+            return False
+
+    async def _try_reconnect(self) -> None:
+        now = time.time()
+        if now < self._next_reconnect_at:
+            return
+        self._next_reconnect_at = now + 60
+        if await self._connect_once():
+            # Restart message handler after successful reconnection
+            if self._message_task and not self._message_task.done():
+                self._message_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self._message_task
+            self._message_task = asyncio.create_task(self._message_handler())
+
     async def _disconnect(self) -> None:
         if self._client:
             try:
@@ -514,19 +527,6 @@ class MqttPublisher:
             if entity.command_topic:
                 payload["command_topic"] = f"{self._config.topic_prefix}/{entity.command_topic}"
             await self._client.publish(topic, payload=json.dumps(payload), retain=True)
-
-    async def _try_reconnect(self) -> None:
-        now = time.time()
-        if now < self._next_reconnect_at:
-            return
-        self._next_reconnect_at = now + 60
-        if await self._connect_once():
-            # Restart message handler after successful reconnection
-            if self._message_task and not self._message_task.done():
-                self._message_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await self._message_task
-            self._message_task = asyncio.create_task(self._message_handler())
 
     async def _message_handler(self) -> None:
         """Handle incoming MQTT command messages."""

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -86,6 +86,7 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
             relay=self.mock_relay,
             car=self.mock_car,
         )
+        self.publisher._state_restore_timeout_s = 0  # skip wait in tests
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_start_connects_and_publishes_discovery(self, mock_client_cls: Any):
@@ -260,19 +261,23 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
                 }
             }
         )
-        mock_msg = MagicMock()
-        mock_msg.payload = retained_payload
 
-        messages_iter = AsyncMock()
-        messages_iter.__anext__ = AsyncMock(return_value=mock_msg)
-        mock_client.messages = messages_iter
+        async def mock_messages():
+            yield MagicMock(payload=retained_payload.encode(), topic="pvcontrol/state")
+            # Don't exhaust - wait forever like a real MQTT connection
+            await asyncio.Event().wait()
 
+        mock_client.messages = mock_messages()
+
+        self.publisher._state_restore_timeout_s = 0.5  # short timeout for this test
         await self.publisher.start()
-        await self.publisher.restore_state()
 
         self.mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
         self.mock_controller.set_phase_mode.assert_called_once_with(PhaseMode.CHARGE_1P)
         self.mock_controller.set_desired_priority.assert_called_once_with(Priority.CAR)
+
+        # unsubscribed after processing retained message
+        mock_client.unsubscribe.assert_called_once_with("pvcontrol/state")
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_restore_state_timeout_does_not_crash(self, mock_client_cls: Any):
@@ -284,18 +289,16 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
         mock_client.unsubscribe = AsyncMock()
         mock_client_cls.return_value = mock_client
 
-        messages_iter = AsyncMock()
-        messages_iter.__anext__ = AsyncMock(side_effect=TimeoutError)
-        mock_client.messages = messages_iter
+        async def mock_messages():
+            # No messages - wait forever (simulates timeout)
+            await asyncio.Event().wait()
+            yield  # make it a generator
 
+        mock_client.messages = mock_messages()
+
+        self.publisher._state_restore_timeout_s = 0.1  # short timeout
         await self.publisher.start()
-        await self.publisher.restore_state()
-        # Should not raise — just logs and continues
-
-    async def test_restore_state_without_connection(self):
-        self.publisher._client = None
-        await self.publisher.restore_state()
-        # Should not raise
+        mock_client.unsubscribe.assert_called_once_with("pvcontrol/state")
 
     # Don't restore phase_mode if it's DISABLED. DISABLED is set only if phase switching relay is not available
     # when pvcontrol was deployed on a node without it.
@@ -318,15 +321,16 @@ class MqttPublisherTest(unittest.IsolatedAsyncioTestCase):
                 }
             }
         )
-        mock_msg = MagicMock()
-        mock_msg.payload = retained_payload
 
-        messages_iter = AsyncMock()
-        messages_iter.__anext__ = AsyncMock(return_value=mock_msg)
-        mock_client.messages = messages_iter
+        async def mock_messages():
+            yield MagicMock(payload=retained_payload.encode(), topic="pvcontrol/state")
+            # Don't exhaust - wait forever like a real MQTT connection
+            await asyncio.Event().wait()
 
+        mock_client.messages = mock_messages()
+
+        self.publisher._state_restore_timeout_s = 0.5  # short timeout for this test
         await self.publisher.start()
-        await self.publisher.restore_state()
 
         self.mock_controller.set_desired_mode.assert_called_once_with(ChargeMode.PV_ONLY)
         self.mock_controller.set_phase_mode.assert_not_called()
@@ -396,6 +400,7 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
             relay=self.mock_relay,
             car=self.mock_car,
         )
+        self.publisher._state_restore_timeout_s = 0  # skip wait in tests
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_start_subscribes_to_command_topics(self, mock_client_cls: Any):
@@ -454,10 +459,8 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
         mock_client.subscribe = AsyncMock()
         mock_client_cls.return_value = mock_client
 
-        # Simulate receiving a message on the desired_mode command topic
+        # Simulate receiving a message on the desired_mode command topic (no state message)
         async def mock_messages():
-            # First yield simulates the restore_state message (if any), then our command
-            yield MagicMock(payload=b'{"controller": {"desired_mode": "OFF"}}', topic="pvcontrol/state")
             yield MagicMock(payload=b"PV_ONLY", topic="pvcontrol/controller/desired_mode/set")
 
         mock_client.messages = mock_messages()
@@ -479,7 +482,6 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
         mock_client_cls.return_value = mock_client
 
         async def mock_messages():
-            yield MagicMock(payload=b'{"controller": {"phase_mode": "AUTO"}}', topic="pvcontrol/state")
             yield MagicMock(payload=b"CHARGE_1P", topic="pvcontrol/controller/phase_mode/set")
 
         mock_client.messages = mock_messages()
@@ -500,7 +502,6 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
         mock_client_cls.return_value = mock_client
 
         async def mock_messages():
-            yield MagicMock(payload=b'{"controller": {"desired_priority": "AUTO"}}', topic="pvcontrol/state")
             yield MagicMock(payload=b"CAR", topic="pvcontrol/controller/desired_priority/set")
 
         mock_client.messages = mock_messages()
@@ -555,7 +556,7 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_stop_cancels_message_handler(self, mock_client_cls: Any):
-        """Stop should cancel the message handler scheduler."""
+        """Stop should cancel the message handler task."""
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
@@ -563,12 +564,22 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
         mock_client.subscribe = AsyncMock()
         mock_client_cls.return_value = mock_client
 
+        # Create an async generator that waits forever (like a real MQTT connection)
+        async def mock_messages():
+            await asyncio.Event().wait()
+            yield  # make it a generator
+
+        mock_client.messages = mock_messages()
+
         await self.publisher.start()
-        self.assertTrue(self.publisher._message_scheduler.is_started())
+        message_task = self.publisher._message_task
+        self.assertIsNotNone(message_task)
+        assert message_task is not None
+        self.assertFalse(message_task.done())
 
         await self.publisher.stop()
 
-        self.assertFalse(self.publisher._message_scheduler.is_started())
+        self.assertTrue(message_task.done())
 
     @patch("pvcontrol.mqtt.aiomqtt.Client")
     async def test_reconnect_restarts_message_handler(self, mock_client_cls: Any):
@@ -592,13 +603,14 @@ class MqttPublisherCommandTest(unittest.IsolatedAsyncioTestCase):
         mock_client_cls.side_effect = [mock_client1, mock_client2]
 
         await self.publisher.start()
-        self.assertTrue(self.publisher._message_scheduler.is_started())
+        self.assertIsNotNone(self.publisher._message_task)
 
         # Simulate disconnection and reconnection
         self.publisher._client = None
+        await self.publisher.publish_state()
         self.publisher._next_reconnect_at = 0  # Force immediate retry
 
         await self.publisher._try_reconnect()
 
-        # Scheduler should still be running (same task, but coroutine will run again on reconnect)
-        self.assertTrue(self.publisher._message_scheduler.is_started())
+        # Message handler task should be restarted (new task)
+        self.assertIsNotNone(self.publisher._message_task)


### PR DESCRIPTION
- ensure that state is read from mqtt on startup (and only on startup)
- use simple task instead of AsyncScheduler for mqtt command handlers